### PR TITLE
fix: non-breaking bug fixes in tracing module

### DIFF
--- a/tracing/internal/convert/convert.go
+++ b/tracing/internal/convert/convert.go
@@ -26,6 +26,7 @@ func ToKeyVals(attr slog.Attr) (kvs []attribute.KeyValue) {
 	case slog.KindBool:
 		return []attribute.KeyValue{attribute.Bool(key, val.Bool())}
 	case slog.KindDuration:
+		return []attribute.KeyValue{attribute.Float64(key, val.Duration().Seconds())}
 	case slog.KindFloat64:
 		return []attribute.KeyValue{attribute.Float64(key, val.Float64())}
 	case slog.KindInt64:

--- a/tracing/internal/convert/convert_test.go
+++ b/tracing/internal/convert/convert_test.go
@@ -42,6 +42,7 @@ func TestToKeyVal(t *testing.T) {
 		in       slog.Attr
 		expected []attribute.KeyValue
 	}{
+		{slog.Duration("duration", 1500 * time.Millisecond), []attribute.KeyValue{attribute.Float64("duration", 1.5)}},
 		{slog.Bool("bool", true), []attribute.KeyValue{attribute.Bool("bool", true)}},
 		{slog.Float64("float64", 1.0), []attribute.KeyValue{attribute.Float64("float64", 1.0)}},
 		{slog.Int64("int64", 1), []attribute.KeyValue{attribute.Int64("int64", 1)}},

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	instrumentationCodeProviderName = "github.com/els0r/goProbe/pkg/tracing"
+	instrumentationCodeProviderName = "github.com/els0r/telemetry/tracing"
 )
 
 type tracingConfig struct {
@@ -142,9 +142,6 @@ func NewTracerProvider(opts ...Option) (tp *sdktrace.TracerProvider, err error) 
 		return nil, errorNoSpanExporter
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
-	}
 	// Register the trace exporter with a TracerProvider, using a batch
 	// span processor to aggregate spans before export.
 	bsp := sdktrace.NewBatchSpanProcessor(exporter)

--- a/tracing/traceparent.go
+++ b/tracing/traceparent.go
@@ -60,11 +60,10 @@ func ContextFromW3CTraceparentHeader(ctx context.Context, traceparentHeader stri
 	}
 
 	if traceparentHeader == "" {
-		return context.Background()
+		return ctx
 	}
 
 	p := propagation.TraceContext{}
-	otel.SetTextMapPropagator(p)
 
 	return p.Extract(ctx,
 		propagation.MapCarrier{w3traceparentHeaderKey: traceparentHeader},
@@ -79,11 +78,10 @@ func ContextFromB3SingleHeader(ctx context.Context, b3Header string) context.Con
 	}
 
 	if b3Header == "" {
-		return context.Background()
+		return ctx
 	}
 
 	p := b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader | b3.B3SingleHeader))
-	otel.SetTextMapPropagator(p)
 
 	return p.Extract(ctx, propagation.MapCarrier{b3SingleHeaderKey: b3Header})
 }
@@ -134,7 +132,7 @@ func GetSpanID(ctx context.Context) (spanID string) {
 		return spanID
 	}
 	sc := trace.SpanContextFromContext(ctx)
-	if sc.HasTraceID() {
+	if sc.IsValid() {
 		return sc.SpanID().String()
 	}
 	return spanID


### PR DESCRIPTION
- Remove global propagator mutation from ContextFrom*Header functions; use local propagator instances for extraction only
- Remove dead/unreachable error check in NewTracerProvider
- Return caller's ctx instead of context.Background() on empty header
- Fix instrumentation scope name (was goProbe, now telemetry/tracing)
- Implement KindDuration conversion to float64 seconds in convert.ToKeyVals
- Use sc.IsValid() instead of sc.HasTraceID() in GetSpanID